### PR TITLE
GlobalMuonTrackExt - Extended track class for multiple candidate storage

### DIFF
--- a/MUONMatcher.cxx
+++ b/MUONMatcher.cxx
@@ -910,7 +910,7 @@ void MUONMatcher::finalize()
   std::cout << "Computing Track Labels..." << std::endl;
 
   if (!mMatchSaveAll) {
-    for (auto &gTrack : mGlobalMuonTracks) {
+    for (auto& gTrack : mGlobalMuonTracks) {
       if (gTrack.closeMatch())
         nCloseMatches++;
       auto bestMFTTrackMatchID = gTrack.getBestMFTTrackMatchID();
@@ -956,7 +956,7 @@ void MUONMatcher::finalize()
     }
 
   } else { // if matchSaveAll is set
-    for (auto &gTrack : mGlobalMuonTracksExt) {
+    for (auto& gTrack : mGlobalMuonTracksExt) {
       if (gTrack.closeMatch())
         nCloseMatches++;
       auto bestMFTTrackMatchID = gTrack.getBestMFTTrackMatchID();
@@ -1042,11 +1042,13 @@ void MUONMatcher::finalize()
 //_________________________________________________________________________________________________
 void MUONMatcher::saveGlobalMuonTracks()
 {
-
-  TFile outFile("GlobalMuonTracks.root", "RECREATE");
+  std::string gmtracksfilename;
+  gmtracksfilename =
+    mMatchSaveAll ? "GlobalMuonTracksExt.root" : "GlobalMuonTracks.root";
+  TFile outFile(gmtracksfilename.c_str(), "RECREATE");
   TTree outTree("o2sim", "Global Muon Tracks");
   std::vector<GlobalMuonTrack>* tracks = &mGlobalMuonTracks;
-  std::vector<GlobalMuonTrackExt> *tracksExt = &mGlobalMuonTracksExt;
+  std::vector<GlobalMuonTrackExt>* tracksExt = &mGlobalMuonTracksExt;
   MCLabels* trackLabels = &mGlobalTrackLabels;
 
   if (!mMatchSaveAll) {
@@ -1061,7 +1063,7 @@ void MUONMatcher::saveGlobalMuonTracks()
   outTree.Write();
   outFile.WriteObjectAny(&mMatchingHelper, "MatchingHelper", "Matching Helper");
   outFile.Close();
-  std::cout << "Global Muon Tracks saved to GlobalMuonTracks.root" << std::endl;
+  std::cout << "Global Muon Tracks saved to " << gmtracksfilename << std::endl;
 
   std::ofstream matcherConfig("MatchingConfig.txt");
   matcherConfig << mMatchingHelper.MatchingConfig() << std::endl;
@@ -1088,6 +1090,23 @@ void MUONMatcher::fitTracks()
     }
     GTrackID++;
   }
+
+  GTrackID = 0;
+  for (auto& gTrack : mGlobalMuonTracksExt) {
+    if (gTrack.getBestMFTTrackMatchID() >= 0) {
+      if (mVerbose)
+        std::cout << "Fitting Global Track Ext # " << GTrackID
+                  << " with MFT track # " << gTrack.getBestMFTTrackMatchID()
+                  << ":" << std::endl;
+      fitGlobalMuonTrack(gTrack);
+    } else {
+      if (mVerbose)
+        std::cout << "No matching candidate for MCH Track " << GTrackID
+                  << std::endl;
+    }
+    GTrackID++;
+  }
+
   std::cout << "Finished fitting global muon tracks." << std::endl;
 }
 

--- a/MUONMatcher.h
+++ b/MUONMatcher.h
@@ -45,6 +45,7 @@
 using MCHTrack = o2::mch::TrackParam;
 using MFTTrack = o2::mft::TrackMFT;
 using GlobalMuonTrack = o2::track::GlobalMuonTrack;
+using GlobalMuonTrackExt = o2::track::GlobalMuonTrackExt;
 using MCLabels = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 using MFTCluster = o2::mft::Cluster;
 
@@ -200,6 +201,7 @@ class MUONMatcher
   std::vector<MFTTrack>
     mMCHTracksDummy; // Dummy MCH tracks at the MFT coordinate system
   std::vector<GlobalMuonTrack> mGlobalMuonTracks;
+  std::vector<GlobalMuonTrackExt> mGlobalMuonTracksExt;
   std::vector<MFTCluster> mMFTClusters;
   std::vector<int> mtrackExtClsIDs;
   std::vector<o2::itsmft::ROFRecord> mMFTTracksROFs;

--- a/Read_Match_MCH_MFT.C
+++ b/Read_Match_MCH_MFT.C
@@ -3,6 +3,8 @@
 #ifdef __MAKECINT__
 #pragma link C++ class GlobalMuonTrack + ;
 #pragma link C++ class std::vector < GlobalMuonTrack> + ;
+#pragma link C++ class GlobalMuonTrackExt + ;
+#pragma link C++ class std::vector < GlobalMuonTrackExt> + ;
 #pragma link C++ class MatchingHelper + ;
 #endif
 
@@ -14,6 +16,7 @@
 #endif
 
 using GlobalMuonTrack = o2::track::GlobalMuonTrack;
+using GlobalMuonTrackExt = o2::track::GlobalMuonTrackExt;
 using SMatrix5 = o2::track::SMatrix5;
 using SMatrix55 = o2::track::SMatrix55;
 
@@ -23,8 +26,8 @@ void Read_Match_MCH_MFT(const std::string trkFile = "GlobalMuonTracks.root")
   // Global Muon Tracks
   TFile *trkFileIn = new TFile(trkFile.c_str());
   TTree *gmTrackTree = (TTree *)trkFileIn->Get("o2sim");
-  std::vector<GlobalMuonTrack> trackGMVec, *trackGMVecP = &trackGMVec;
-  gmTrackTree->SetBranchAddress("GlobalMuonTrack", &trackGMVecP);
+  std::vector<GlobalMuonTrackExt> trackGMVec, *trackGMVecP = &trackGMVec;
+  gmTrackTree->SetBranchAddress("GlobalMuonTrackExt", &trackGMVecP);
 
   gmTrackTree->GetEntry(0);
 

--- a/Read_Match_MCH_MFT.C
+++ b/Read_Match_MCH_MFT.C
@@ -20,19 +20,20 @@ using GlobalMuonTrackExt = o2::track::GlobalMuonTrackExt;
 using SMatrix5 = o2::track::SMatrix5;
 using SMatrix55 = o2::track::SMatrix55;
 
-void Read_Match_MCH_MFT(const std::string trkFile = "GlobalMuonTracks.root")
+void Read_Match_MCH_MFT(
+  const std::string trkFile = "GlobalMuonTracksExt.root")
 {
 
   // Global Muon Tracks
-  TFile *trkFileIn = new TFile(trkFile.c_str());
-  TTree *gmTrackTree = (TTree *)trkFileIn->Get("o2sim");
+  TFile* trkFileIn = new TFile(trkFile.c_str());
+  TTree* gmTrackTree = (TTree*)trkFileIn->Get("o2sim");
   std::vector<GlobalMuonTrackExt> trackGMVec, *trackGMVecP = &trackGMVec;
   gmTrackTree->SetBranchAddress("GlobalMuonTrackExt", &trackGMVecP);
 
   gmTrackTree->GetEntry(0);
 
   Int_t igm = 0;
-  for (auto &gmTrack : trackGMVec) {
+  for (auto& gmTrack : trackGMVec) {
     const SMatrix5& trackMCHpar = gmTrack.getParametersMCH();
     const SMatrix5& trackMFTpar = gmTrack.getParametersMFT();
     const SMatrix55& trackMCHcov = gmTrack.getCovariancesMCH();
@@ -55,14 +56,14 @@ void Read_Match_MCH_MFT(const std::string trkFile = "GlobalMuonTracks.root")
     printf("MCH covariances:\n");
     for (Int_t i = 0; i < 5; i++) {
       for (Int_t j = 0; j < 5; j++) {
-	printf("%f ", trackMCHcov(i,j));
+        printf("%f ", trackMCHcov(i, j));
       }
       printf("\n");
     }
     printf("MFT covariances:\n");
     for (Int_t i = 0; i < 5; i++) {
       for (Int_t j = 0; j < 5; j++) {
-	printf("%f ", trackMFTcov(i,j));
+        printf("%f ", trackMFTcov(i, j));
       }
       printf("\n");
     }
@@ -71,5 +72,4 @@ void Read_Match_MCH_MFT(const std::string trkFile = "GlobalMuonTracks.root")
   }
 
   trkFileIn->Close();
-
 }

--- a/include/GlobalMuonTrack.h
+++ b/include/GlobalMuonTrack.h
@@ -13,87 +13,104 @@
 namespace o2::track
 {
 
-class GlobalMuonTrack : public o2::track::TrackParCovFwd
-{
   using ClusRefs = o2::dataformats::RangeRefComp<4>;
   using SMatrix55 =
     ROOT::Math::SMatrix<double, 5, 5, ROOT::Math::MatRepSym<double, 5>>;
   using SMatrix5 = ROOT::Math::SVector<Double_t, 5>;
 
- public:
-  GlobalMuonTrack() = default;
-  GlobalMuonTrack(const GlobalMuonTrack& t) = default;
-  ~GlobalMuonTrack() = default;
+  class GlobalMuonTrack : public o2::track::TrackParCovFwd {
 
-  std::uint32_t getROFrame() const { return mROFrame; }
-  void setROFrame(std::uint32_t f) { mROFrame = f; }
+  public:
+    GlobalMuonTrack() = default;
+    GlobalMuonTrack(const GlobalMuonTrack &t) = default;
+    ~GlobalMuonTrack() = default;
 
-  void setMatchingChi2(double chi2) { mMatchingChi2 = chi2; }
-  double getMatchingChi2() { return mMatchingChi2; }
-  void countCandidate() { mNMFTCandidates++; }
-  int getNMFTCandidates() { return mNMFTCandidates; }
+    std::uint32_t getROFrame() const { return mROFrame; }
+    void setROFrame(std::uint32_t f) { mROFrame = f; }
 
-  void setBestMFTTrackMatchID(int ID) { mBestMFTTrackMatchID = ID; }
-  double getBestMFTTrackMatchID() { return mBestMFTTrackMatchID; }
-  void setCloseMatch() { mCloseMatch = true; }
-  bool closeMatch() { return mCloseMatch; }
-  void computeResiduals2Cov(const o2::track::TrackParCovFwd& t)
-  {
-    mResiduals2Cov(0) =
-      (getX() - t.getX()) /
-      TMath::Sqrt(getCovariances()(0, 0) + t.getCovariances()(0, 0));
-    mResiduals2Cov(1) =
-      (getY() - t.getY()) /
-      TMath::Sqrt(getCovariances()(1, 1) + t.getCovariances()(1, 1));
-    mResiduals2Cov(2) =
-      (getPhi() - t.getPhi()) /
-      TMath::Sqrt(getCovariances()(2, 2) + t.getCovariances()(2, 2));
-    mResiduals2Cov(3) =
-      (getTanl() - t.getTanl()) /
-      TMath::Sqrt(getCovariances()(3, 3) + t.getCovariances()(3, 3));
-    mResiduals2Cov(4) =
-      (getInvQPt() - t.getInvQPt()) /
-      TMath::Sqrt(getCovariances()(4, 4) + t.getCovariances()(4, 4));
-    ;
-  }
-  const SMatrix5& getResiduals2Cov() { return mResiduals2Cov; }
+    void setMatchingChi2(double chi2) { mMatchingChi2 = chi2; }
+    double getMatchingChi2() { return mMatchingChi2; }
+    void countCandidate() { mNMFTCandidates++; }
+    int getNMFTCandidates() { return mNMFTCandidates; }
 
-  void print() const;
+    void setBestMFTTrackMatchID(int ID) { mBestMFTTrackMatchID = ID; }
+    double getBestMFTTrackMatchID() { return mBestMFTTrackMatchID; }
+    void setCloseMatch() { mCloseMatch = true; }
+    bool closeMatch() { return mCloseMatch; }
+    void computeResiduals2Cov(const o2::track::TrackParCovFwd &t) {
+      mResiduals2Cov(0) =
+          (getX() - t.getX()) /
+          TMath::Sqrt(getCovariances()(0, 0) + t.getCovariances()(0, 0));
+      mResiduals2Cov(1) =
+          (getY() - t.getY()) /
+          TMath::Sqrt(getCovariances()(1, 1) + t.getCovariances()(1, 1));
+      mResiduals2Cov(2) =
+          (getPhi() - t.getPhi()) /
+          TMath::Sqrt(getCovariances()(2, 2) + t.getCovariances()(2, 2));
+      mResiduals2Cov(3) =
+          (getTanl() - t.getTanl()) /
+          TMath::Sqrt(getCovariances()(3, 3) + t.getCovariances()(3, 3));
+      mResiduals2Cov(4) =
+          (getInvQPt() - t.getInvQPt()) /
+          TMath::Sqrt(getCovariances()(4, 4) + t.getCovariances()(4, 4));
+      ;
+    }
+    const SMatrix5 &getResiduals2Cov() { return mResiduals2Cov; }
 
-  /// for performance studies: store parameters and covariances for the MCH and MFT
-  const SMatrix5& getParametersMCH() const { return mParametersMCH; }
-  const SMatrix5& getParametersMFT() const { return mParametersMFT; }
-  void setParametersMCH(const SMatrix5& parameters) { mParametersMCH = parameters; }
-  void setParametersMFT(const SMatrix5& parameters) { mParametersMFT = parameters; }
-  const SMatrix55& getCovariancesMCH() const { return mCovariancesMCH; }
-  const SMatrix55& getCovariancesMFT() const { return mCovariancesMFT; }
-  void setCovariancesMCH(const SMatrix55& covariances)
-  {
-    mCovariancesMCH = covariances;
-  }
-  void setCovariancesMFT(const SMatrix55& covariances)
-  {
-    mCovariancesMFT = covariances;
-  }
-  void setMCHTrackID(int ID) { mMCHTrackID = ID; }
-  double getMCHTrackID() { return mMCHTrackID; }
+    void print() const;
 
- private:
-  std::uint32_t mROFrame = 0; ///< RO Frame
-  double mMatchingChi2 = 1.0E308;
-  int mBestMFTTrackMatchID = -1;
-  int mNMFTCandidates = 0; // Number of candidates within search cut
-  bool mCloseMatch = false;
+    void setMCHTrackID(int ID) { mMCHTrackID = ID; }
+    double getMCHTrackID() { return mMCHTrackID; }
 
-  SMatrix5 mResiduals2Cov;
+  private:
+    std::uint32_t mROFrame = 0; ///< RO Frame
+    double mMatchingChi2 = 1.0E308;
+    int mBestMFTTrackMatchID = -1;
+    int mMCHTrackID = -1;
+    int mNMFTCandidates = 0; // Number of candidates within search cut
+    bool mCloseMatch = false;
+    SMatrix5 mResiduals2Cov;
+  };
 
-  /// for performance studies: store parameters and covariances for the MCH and MFT
-  SMatrix5 mParametersMCH{};   ///< \brief Track parameters, MCH part of the track
-  SMatrix5 mParametersMFT{};   ///< \brief Track parameters, MFT part of the track
-  SMatrix55 mCovariancesMCH{}; ///< \brief Covariance matrix of track parameters, MCH
-  SMatrix55 mCovariancesMFT{}; ///< \brief Covariance matrix of track parameters, MFT
-  int mMCHTrackID = -1;
-};
+  class GlobalMuonTrackExt : public o2::track::GlobalMuonTrack {
+
+  public:
+    GlobalMuonTrackExt() = default;
+    GlobalMuonTrackExt(const GlobalMuonTrackExt &t) = default;
+    ~GlobalMuonTrackExt() = default;
+    GlobalMuonTrackExt(const GlobalMuonTrack &t) : GlobalMuonTrack(t) {}
+
+    /// for performance studies: store parameters and covariances for the MCH
+    /// and MFT
+    const SMatrix5 &getParametersMCH() const { return mParametersMCH; }
+    const SMatrix5 &getParametersMFT() const { return mParametersMFT; }
+    void setParametersMCH(const SMatrix5 &parameters) {
+      mParametersMCH = parameters;
+    }
+    void setParametersMFT(const SMatrix5 &parameters) {
+      mParametersMFT = parameters;
+    }
+    const SMatrix55 &getCovariancesMCH() const { return mCovariancesMCH; }
+    const SMatrix55 &getCovariancesMFT() const { return mCovariancesMFT; }
+    void setCovariancesMCH(const SMatrix55 &covariances) {
+      mCovariancesMCH = covariances;
+    }
+    void setCovariancesMFT(const SMatrix55 &covariances) {
+      mCovariancesMFT = covariances;
+    }
+
+  private:
+    /// for performance studies: store parameters and covariances for the MCH
+    /// and MFT
+    SMatrix5
+        mParametersMCH{}; ///< \brief Track parameters, MCH part of the track
+    SMatrix5
+        mParametersMFT{}; ///< \brief Track parameters, MFT part of the track
+    SMatrix55 mCovariancesMCH{}; ///< \brief Covariance matrix of track
+                                 ///< parameters, MCH
+    SMatrix55 mCovariancesMFT{}; ///< \brief Covariance matrix of track
+                                 ///< parameters, MFT
+  };
 } // namespace o2::track
 
 //_________________________________________________________________________________________________

--- a/include/GlobalMuonTrack.h
+++ b/include/GlobalMuonTrack.h
@@ -13,104 +13,111 @@
 namespace o2::track
 {
 
-  using ClusRefs = o2::dataformats::RangeRefComp<4>;
-  using SMatrix55 =
-    ROOT::Math::SMatrix<double, 5, 5, ROOT::Math::MatRepSym<double, 5>>;
-  using SMatrix5 = ROOT::Math::SVector<Double_t, 5>;
+using ClusRefs = o2::dataformats::RangeRefComp<4>;
+using SMatrix55 =
+  ROOT::Math::SMatrix<double, 5, 5, ROOT::Math::MatRepSym<double, 5>>;
+using SMatrix5 = ROOT::Math::SVector<Double_t, 5>;
 
-  class GlobalMuonTrack : public o2::track::TrackParCovFwd {
+class GlobalMuonTrack : public o2::track::TrackParCovFwd
+{
 
-  public:
-    GlobalMuonTrack() = default;
-    GlobalMuonTrack(const GlobalMuonTrack &t) = default;
-    ~GlobalMuonTrack() = default;
+ public:
+  GlobalMuonTrack() = default;
+  GlobalMuonTrack(const GlobalMuonTrack& t) = default;
+  ~GlobalMuonTrack() = default;
 
-    std::uint32_t getROFrame() const { return mROFrame; }
-    void setROFrame(std::uint32_t f) { mROFrame = f; }
+  std::uint32_t getROFrame() const { return mROFrame; }
+  void setROFrame(std::uint32_t f) { mROFrame = f; }
 
-    void setMatchingChi2(double chi2) { mMatchingChi2 = chi2; }
-    double getMatchingChi2() { return mMatchingChi2; }
-    void countCandidate() { mNMFTCandidates++; }
-    int getNMFTCandidates() { return mNMFTCandidates; }
+  void setMatchingChi2(double chi2) { mMatchingChi2 = chi2; }
+  double getMatchingChi2() { return mMatchingChi2; }
+  void countCandidate() { mNMFTCandidates++; }
+  int getNMFTCandidates() { return mNMFTCandidates; }
 
-    void setBestMFTTrackMatchID(int ID) { mBestMFTTrackMatchID = ID; }
-    double getBestMFTTrackMatchID() { return mBestMFTTrackMatchID; }
-    void setCloseMatch() { mCloseMatch = true; }
-    bool closeMatch() { return mCloseMatch; }
-    void computeResiduals2Cov(const o2::track::TrackParCovFwd &t) {
-      mResiduals2Cov(0) =
-          (getX() - t.getX()) /
-          TMath::Sqrt(getCovariances()(0, 0) + t.getCovariances()(0, 0));
-      mResiduals2Cov(1) =
-          (getY() - t.getY()) /
-          TMath::Sqrt(getCovariances()(1, 1) + t.getCovariances()(1, 1));
-      mResiduals2Cov(2) =
-          (getPhi() - t.getPhi()) /
-          TMath::Sqrt(getCovariances()(2, 2) + t.getCovariances()(2, 2));
-      mResiduals2Cov(3) =
-          (getTanl() - t.getTanl()) /
-          TMath::Sqrt(getCovariances()(3, 3) + t.getCovariances()(3, 3));
-      mResiduals2Cov(4) =
-          (getInvQPt() - t.getInvQPt()) /
-          TMath::Sqrt(getCovariances()(4, 4) + t.getCovariances()(4, 4));
-      ;
-    }
-    const SMatrix5 &getResiduals2Cov() { return mResiduals2Cov; }
+  void setBestMFTTrackMatchID(int ID) { mBestMFTTrackMatchID = ID; }
+  double getBestMFTTrackMatchID() { return mBestMFTTrackMatchID; }
+  void setCloseMatch() { mCloseMatch = true; }
+  bool closeMatch() { return mCloseMatch; }
+  void computeResiduals2Cov(const o2::track::TrackParCovFwd& t)
+  {
+    mResiduals2Cov(0) =
+      (getX() - t.getX()) /
+      TMath::Sqrt(getCovariances()(0, 0) + t.getCovariances()(0, 0));
+    mResiduals2Cov(1) =
+      (getY() - t.getY()) /
+      TMath::Sqrt(getCovariances()(1, 1) + t.getCovariances()(1, 1));
+    mResiduals2Cov(2) =
+      (getPhi() - t.getPhi()) /
+      TMath::Sqrt(getCovariances()(2, 2) + t.getCovariances()(2, 2));
+    mResiduals2Cov(3) =
+      (getTanl() - t.getTanl()) /
+      TMath::Sqrt(getCovariances()(3, 3) + t.getCovariances()(3, 3));
+    mResiduals2Cov(4) =
+      (getInvQPt() - t.getInvQPt()) /
+      TMath::Sqrt(getCovariances()(4, 4) + t.getCovariances()(4, 4));
+    ;
+  }
+  const SMatrix5& getResiduals2Cov() { return mResiduals2Cov; }
 
-    void print() const;
+  void print() const;
 
-    void setMCHTrackID(int ID) { mMCHTrackID = ID; }
-    double getMCHTrackID() { return mMCHTrackID; }
+  void setMCHTrackID(int ID) { mMCHTrackID = ID; }
+  double getMCHTrackID() { return mMCHTrackID; }
 
-  private:
-    std::uint32_t mROFrame = 0; ///< RO Frame
-    double mMatchingChi2 = 1.0E308;
-    int mBestMFTTrackMatchID = -1;
-    int mMCHTrackID = -1;
-    int mNMFTCandidates = 0; // Number of candidates within search cut
-    bool mCloseMatch = false;
-    SMatrix5 mResiduals2Cov;
-  };
+ private:
+  std::uint32_t mROFrame = 0; ///< RO Frame
+  double mMatchingChi2 = 1.0E308;
+  int mBestMFTTrackMatchID = -1;
+  int mMCHTrackID = -1;
+  int mNMFTCandidates = 0; // Number of candidates within search cut
+  bool mCloseMatch = false;
+  SMatrix5 mResiduals2Cov;
+};
 
-  class GlobalMuonTrackExt : public o2::track::GlobalMuonTrack {
+class GlobalMuonTrackExt : public o2::track::GlobalMuonTrack
+{
 
-  public:
-    GlobalMuonTrackExt() = default;
-    GlobalMuonTrackExt(const GlobalMuonTrackExt &t) = default;
-    ~GlobalMuonTrackExt() = default;
-    GlobalMuonTrackExt(const GlobalMuonTrack &t) : GlobalMuonTrack(t) {}
+ public:
+  GlobalMuonTrackExt() = default;
+  GlobalMuonTrackExt(const GlobalMuonTrackExt& t) = default;
+  ~GlobalMuonTrackExt() = default;
+  GlobalMuonTrackExt(const GlobalMuonTrack& t) : GlobalMuonTrack(t) {}
 
-    /// for performance studies: store parameters and covariances for the MCH
-    /// and MFT
-    const SMatrix5 &getParametersMCH() const { return mParametersMCH; }
-    const SMatrix5 &getParametersMFT() const { return mParametersMFT; }
-    void setParametersMCH(const SMatrix5 &parameters) {
-      mParametersMCH = parameters;
-    }
-    void setParametersMFT(const SMatrix5 &parameters) {
-      mParametersMFT = parameters;
-    }
-    const SMatrix55 &getCovariancesMCH() const { return mCovariancesMCH; }
-    const SMatrix55 &getCovariancesMFT() const { return mCovariancesMFT; }
-    void setCovariancesMCH(const SMatrix55 &covariances) {
-      mCovariancesMCH = covariances;
-    }
-    void setCovariancesMFT(const SMatrix55 &covariances) {
-      mCovariancesMFT = covariances;
-    }
+  /// for performance studies: store parameters and covariances for the MCH
+  /// and MFT
+  const SMatrix5& getParametersMCH() const { return mParametersMCH; }
+  const SMatrix5& getParametersMFT() const { return mParametersMFT; }
+  void setParametersMCH(const SMatrix5& parameters)
+  {
+    mParametersMCH = parameters;
+  }
+  void setParametersMFT(const SMatrix5& parameters)
+  {
+    mParametersMFT = parameters;
+  }
+  const SMatrix55& getCovariancesMCH() const { return mCovariancesMCH; }
+  const SMatrix55& getCovariancesMFT() const { return mCovariancesMFT; }
+  void setCovariancesMCH(const SMatrix55& covariances)
+  {
+    mCovariancesMCH = covariances;
+  }
+  void setCovariancesMFT(const SMatrix55& covariances)
+  {
+    mCovariancesMFT = covariances;
+  }
 
-  private:
-    /// for performance studies: store parameters and covariances for the MCH
-    /// and MFT
-    SMatrix5
-        mParametersMCH{}; ///< \brief Track parameters, MCH part of the track
-    SMatrix5
-        mParametersMFT{}; ///< \brief Track parameters, MFT part of the track
-    SMatrix55 mCovariancesMCH{}; ///< \brief Covariance matrix of track
-                                 ///< parameters, MCH
-    SMatrix55 mCovariancesMFT{}; ///< \brief Covariance matrix of track
-                                 ///< parameters, MFT
-  };
+ private:
+  /// for performance studies: store parameters and covariances for the MCH
+  /// and MFT
+  SMatrix5
+    mParametersMCH{}; ///< \brief Track parameters, MCH part of the track
+  SMatrix5
+    mParametersMFT{};          ///< \brief Track parameters, MFT part of the track
+  SMatrix55 mCovariancesMCH{}; ///< \brief Covariance matrix of track
+                               ///< parameters, MCH
+  SMatrix55 mCovariancesMFT{}; ///< \brief Covariance matrix of track
+                               ///< parameters, MFT
+};
 } // namespace o2::track
 
 //_________________________________________________________________________________________________

--- a/runMatching.C
+++ b/runMatching.C
@@ -6,7 +6,9 @@
 
 //#ifdef __MAKECINT__
 #pragma link C++ class GlobalMuonTrack + ;
+#pragma link C++ class GlobalMuonTrackExt + ;
 #pragma link C++ class std::vector < GlobalMuonTrack> + ;
+#pragma link C++ class std::vector < GlobalMuonTrackExt> + ;
 #pragma link C++ class tempMCHTrack + ;
 #pragma link C++ class o2::mch::TrackExtrap + ;
 #pragma link C++ class std::vector < tempMCHTrack> + ;


### PR DESCRIPTION
Method to store multiple GlobalMuonTrack candidate per MCH track moved to class GlobalMuonTrackExt. MUONMatcher and Read_Match_MCH_MFT.C adapted accordingly. 

@bovulpes , please take a look at these changes. 