### PR TITLE
Interface updates

### DIFF
--- a/MLTraining.C
+++ b/MLTraining.C
@@ -25,7 +25,7 @@
 
 using namespace TMVA;
 
-string DNN_read(const std::string& MLLayout, const std::string& MLStrat, const std::string& MLOpt, const char* filename = "MLConfigs.xml")
+string DNN_read(const std::string& MLLayout, const std::string& MLStrat, const std::string& MLOpt, const char* filename = "../MLConfigs.xml")
 {
   // First create engine
   TXMLEngine xml;
@@ -110,16 +110,16 @@ void DLRegression(std::string input_name, std::string trainingfile, std::string 
 
   TString methodname = input_name.c_str();
 
-  std::size_t pos1 = trainingfile.find("MLTraining_");
+  std::size_t rpos = trainingfile.rfind('/');
   std::size_t pos = trainingfile.find(".root");
-  methodname += "_" + trainingfile.substr(pos1, pos);
+  methodname += "_" + trainingfile.substr(rpos+1, (pos-(rpos+1)));
   TString outfileName(methodname + ".root");
   TFile* outputFile = TFile::Open(outfileName, "RECREATE");
   TMVA::Factory* factory = new TMVA::Factory("Trained_ML", outputFile,
                                              "!V:!Silent:Color:DrawProgressBar:AnalysisType=Regression");
 
   // Dataloader object - this will handle the data (The argument also defines the name of the directory containing the weights' file)
-  TMVA::DataLoader* dataloader = new TMVA::DataLoader("trainedMLs");
+  TMVA::DataLoader* dataloader = new TMVA::DataLoader("trainedML");
 
   // Define the input variables that shall be used for the MVA training
   // note that you may also use variable expressions, such as: "3*var1/var2*abs(var3)"

--- a/MUONMatcher.cxx
+++ b/MUONMatcher.cxx
@@ -180,20 +180,24 @@ void MUONMatcher::loadMFTTracksOut()
             << " MFT Tracks. Label info:" << std::endl;
   mcLabels->print(std::cout);
   auto mftTrackID = 0;
+  auto nInvalidMFTLabels = 0;
   for (auto& track : mMFTTracks) {
     auto MFTlabel = mftTrackLabels.getLabels(mftTrackID);
-    auto event = MFTlabel[0].getEventID();
-    track.setParameters(track.getOutParam().getParameters());
-    track.setCovariances(track.getOutParam().getCovariances());
-    track.setZ(track.getOutParam().getZ());
-    track.propagateToZhelix(mMatchingPlaneZ, mField_z);
+	if (MFTlabel[0].isValid()) {    
+      auto event = MFTlabel[0].getEventID();
+      track.setParameters(track.getOutParam().getParameters());
+      track.setCovariances(track.getOutParam().getCovariances());
+      track.setZ(track.getOutParam().getZ());
+      track.propagateToZhelix(mMatchingPlaneZ, mField_z);
 
-    mSortedMFTTracks[event].push_back(track);
-    mftTrackLabelsIDx[event].push_back(mftTrackID);
-
+      mSortedMFTTracks[event].push_back(track);
+      mftTrackLabelsIDx[event].push_back(mftTrackID);
+    } else {
+      nInvalidMFTLabels++;
+    }
     mftTrackID++;
   }
-
+  std::cout << " Dropped " << nInvalidMFTLabels << " MFT Tracks with invalid labels (noise)." << std::endl;
   loadMFTClusters();
 }
 

--- a/MUONMatcher.cxx
+++ b/MUONMatcher.cxx
@@ -1810,7 +1810,8 @@ void MUONMatcher::exportTrainingDataRoot(int nMCHTracks)
         auto mftTrackID = 0;
         for (auto mftTrack : mSortedMFTTracks[event]) {
           auto MFTlabel = mftTrackLabels.getLabels(mftTrackLabelsIDx[event][mftTrackID]);
-          if (matchingCut(mchTrack, mftTrack)) {
+          Truth = (int)(MFTlabel[0].getTrackID() == MCHlabel[0].getTrackID());
+          if (Truth || matchingCut(mchTrack, mftTrack)) {
 
             MFT_X = mftTrack.getX();
             MFT_Y = mftTrack.getY();
@@ -1852,7 +1853,7 @@ void MUONMatcher::exportTrainingDataRoot(int nMCHTracks)
             MCH_Cov24 = mchTrack.getCovariances()(2, 4);
             MCH_Cov34 = mchTrack.getCovariances()(3, 4);
             MCH_Cov44 = mchTrack.getCovariances()(4, 4);
-            Truth = (int)(MFTlabel[0].getTrackID() == MCHlabel[0].getTrackID());
+
             Truth ? nCorrectPairs++ : nFakesPairs++;
             pairID++;
             matchTree->Fill();

--- a/MUONMatcher.cxx
+++ b/MUONMatcher.cxx
@@ -358,6 +358,8 @@ void MUONMatcher::initGlobalTracks()
       helper.MatchingCutFunc = "_cutDistanceAndAngles";
     if (mCutFunc == &MUONMatcher::matchCut3SigmaXYAngles)
       helper.MatchingCutFunc = "_cutDistanceAndAngles3Sigma";
+    if (mCutFunc == &MUONMatcher::matchCutVarXYAngles)
+      helper.MatchingCutFunc = "_cutDistanceAndAnglesVar";
   }
 }
 
@@ -868,6 +870,27 @@ bool MUONMatcher::matchCut3SigmaXYAngles(const GlobalMuonTrack& mchTrack,
     3 * TMath::Sqrt(mchTrack.getSigma2X() + mchTrack.getSigma2Y());
   auto cutPhi = 3 * TMath::Sqrt(mchTrack.getSigma2Phi());
   auto cutTanl = 3 * TMath::Sqrt(mchTrack.getSigma2Tanl());
+  return (distance < cutDistance) and (dPhi < cutPhi) and (dTheta < cutTanl);
+}
+
+//_________________________________________________________________________________________________
+bool MUONMatcher::matchCutVarXYAngles(const GlobalMuonTrack& mchTrack,
+                                         const MFTTrack& mftTrack)
+{
+
+  if (mChargeCutEnabled && (mchTrack.getCharge() != mftTrack.getCharge()))
+    return false;
+
+  auto dx = mchTrack.getX() - mftTrack.getX();
+  auto dy = mchTrack.getY() - mftTrack.getY();
+  auto dPhi = mchTrack.getPhi() - mftTrack.getPhi();
+  auto dTheta =
+    TMath::Abs(EtaToTheta(mchTrack.getEta()) - EtaToTheta(mftTrack.getEta()));
+  auto distance = TMath::Sqrt(dx * dx + dy * dy);
+  auto cutDistance =
+    3 * 1.3 * TMath::Sqrt(mchTrack.getSigma2X() + mchTrack.getSigma2Y());
+  auto cutPhi = 3 * 1.15 * TMath::Sqrt(mchTrack.getSigma2Phi());
+  auto cutTanl = 3 * 1.22 * TMath::Sqrt(mchTrack.getSigma2Tanl());
   return (distance < cutDistance) and (dPhi < cutPhi) and (dTheta < cutTanl);
 }
 

--- a/MUONMatcher.h
+++ b/MUONMatcher.h
@@ -199,7 +199,7 @@ class MUONMatcher
   void exportTrainingDataRoot(int nMCHTracks = -1);
 
   // Matching cuts
-  void disableChargeMatchCut() { mChargeCutEnabled = false; }
+  void enableChargeMatchCut() { mChargeCutEnabled = true; }
   bool matchingCut(const GlobalMuonTrack&,
                    const MFTTrack&); // Calls configured cut function
 
@@ -332,7 +332,7 @@ class MUONMatcher
   bool mVerbose = false;
   TGeoManager* mGeoManager;
   bool mMatchSaveAll = false;
-  bool mChargeCutEnabled = true;
+  bool mChargeCutEnabled = false;
 
   // TMVA interface
   std::string mTMVAWeightFileName;

--- a/MUONMatcher.h
+++ b/MUONMatcher.h
@@ -267,6 +267,7 @@ class MUONMatcher
   bool matchCutDistanceAndAngles(const GlobalMuonTrack&, const MFTTrack&);
   bool matchCutDistanceSigma(const GlobalMuonTrack&, const MFTTrack&);
   bool matchCut3SigmaXYAngles(const GlobalMuonTrack&, const MFTTrack&);
+  bool matchCutVarXYAngles(const GlobalMuonTrack&, const MFTTrack&);
   void setCutParam(int index, double param)
   {
     if (index > ((int)mCutParams.size() - 1))

--- a/generators/AliGenMimicPbPb.cxx
+++ b/generators/AliGenMimicPbPb.cxx
@@ -190,7 +190,7 @@ void AliGenMimicPbPb::Init() {
 
   AliPDG::AddParticlesToPdgDataBase();
 
-  TFile* inFile = TFile::Open("./inputHijingParam.root");
+  TFile* inFile = TFile::Open("../generators/inputHijingParam.root");
 
   fNum[0] = (TH1F*)inFile->Get("fHistNumFwdPrimePion")     -> Clone();
   fNum[1] = (TH1F*)inFile->Get("fHistNumFwdPrimeKaon")     -> Clone();

--- a/matcher.sh
+++ b/matcher.sh
@@ -105,8 +105,8 @@ Usage()
      --cutParam2 <val2>
        Sets mCutParams[2]=val2; (double)
 
-     --disableChargeMatchCut
-        Disables charge match cut (which is enabled by default on all built-in cut functions but cutDisabled)
+     --enableChargeMatchCut
+        Enables charge match cut (which is disabled by default)
 
      Example:
      ${0##*/} --match --matchFcn matchXYPhiTanl --cutFcn cutDistance --cutParam0 2.0 -o sampletest
@@ -427,8 +427,8 @@ while [ $# -gt 0 ] ; do
     export MATCHING_CUTPARAM2="$2";
     shift 2
     ;;
-    --disableChargeMatchCut)
-    export DISABLECHARGEMATCHCUT="1";
+    --enableChargeMatchCut)
+    export ENABLECHARGEMATCHCUT="1";
     shift 1
     ;;
     --exportTrainingData)

--- a/matcher.sh
+++ b/matcher.sh
@@ -294,12 +294,12 @@ exportMLTrainningData()
 trainML()
 {
 
-  if ! [ -f "${OUTDIR}/MLConfigs.xml" ]; then
-    echo " Machine Learning configuration file absent...copying from script directory to ${OUTDIR}" #TODO option to create configuration file
+  if ! [ -f "MLConfigs.xml" ]; then
+    echo " Machine Learning configuration file absent..." #TODO option to create configuration file
     cp MLConfigs.xml "${OUTDIR}"
   fi
 
-  if ! [ -f "${OUTDIR}/${ML_TRAINING_FILE}" ]; then
+  if ! [ -f "${ML_TRAINING_FILE}" ]; then
     echo " ERROR: could not open data file! "
     exit
   fi
@@ -430,11 +430,11 @@ while [ $# -gt 0 ] ; do
     shift 1
     ;;
     --exportTrainingData)
-    export ML_EXPORTTRAINDATA="$2";
+    export ML_EXPORTTRAINDATA="`realpath $2`";
     shift 2
     ;;
     --weightfile)
-    export ML_WEIGHTFILE="$2";
+    export ML_WEIGHTFILE="`realpath $2`";
     shift 2
     ;;
     --MLScoreCut)

--- a/matcher.sh
+++ b/matcher.sh
@@ -432,7 +432,7 @@ while [ $# -gt 0 ] ; do
     shift 1
     ;;
     --exportTrainingData)
-    export ML_EXPORTTRAINDATA="`realpath $2`";
+    export ML_EXPORTTRAINDATA="$2";
     shift 2
     ;;
     --weightfile)
@@ -460,7 +460,7 @@ while [ $# -gt 0 ] ; do
     shift 2
     ;;
     --trainingdata)
-    export ML_TRAINING_FILE="$2";
+    export ML_TRAINING_FILE="`realpath $2`";
     shift 2
     ;;
     --convert)

--- a/matcher.sh
+++ b/matcher.sh
@@ -94,6 +94,8 @@ Usage()
 
         cutDistanceAndAngles3Sigma - MFT TDR cut (Section 6.5)
 
+        cutDistanceAndAnglesVar - Cut based on observed MCH residuals variances
+
      --cutParam0 <val0>
        Sets mCutParams[0]=val0; (double)
 
@@ -279,7 +281,7 @@ exportMLTrainningData()
     echo "Exporting ML Traning data file on `pwd` ..."
     ## MFT MCH track matching & global muon track fitting:
     alienv setenv ${O2ENV} -c root.exe -e 'gSystem->Load("libO2MCHTracking")' -l -q -b runMatching.C+ | tee training_data_gen.log
-    RESULTSDIR="MLTraning`cat MatchingConfig.txt`"
+    RESULTSDIR="MLTraining`cat MatchingConfig.txt`"
     mkdir -p ${RESULTSDIR}
     cp training_data_gen.log MLTraining_*.root "${RESULTSDIR}"
 

--- a/runMatching.C
+++ b/runMatching.C
@@ -116,6 +116,11 @@ void loadAndSetMatchingConfig()
       std::cout << " Setting " << matching_cutfcn << std::endl;
       matcher.setCutFunction(&MUONMatcher::matchCut3SigmaXYAngles);
     }
+    if (matching_cutfcn.find("cutDistanceAndAnglesVar_") <
+        matching_cutfcn.length()) {
+      std::cout << " Setting " << matching_cutfcn << std::endl;
+      matcher.setCutFunction(&MUONMatcher::matchCutVarXYAngles);
+    }
   }
 
   if (gSystem->Getenv("DISABLECHARGEMATCHCUT")) {

--- a/runMatching.C
+++ b/runMatching.C
@@ -123,8 +123,8 @@ void loadAndSetMatchingConfig()
     }
   }
 
-  if (gSystem->Getenv("DISABLECHARGEMATCHCUT")) {
-    matcher.disableChargeMatchCut();
+  if (gSystem->Getenv("ENABLECHARGEMATCHCUT")) {
+    matcher.enableChargeMatchCut();
   }
 
   if (gSystem->Getenv("MATCHING_CUTPARAM0")) {


### PR DESCRIPTION
Fixed some bugs at matching and generating MCH tracks with hijing;
Improvements when exporting ML training data and for the paths of  training and weigh files, when selecting these;
Adding a new cut function, based on the variances observed ( see MCH residuals covariances plot, generated using ./matcher --check);
Also chaging Charge cut to be disabled by default. It can be enabled with
--enableChargeMatchCut