### PR TITLE
Enables dimuon generators for J/Psi and Upsilon

### DIFF
--- a/generators/AliGenDimuon.cxx
+++ b/generators/AliGenDimuon.cxx
@@ -15,9 +15,9 @@
 
 //====================================================================================================================================================
 //
-//      
 //
-//      
+//
+//
 //
 //====================================================================================================================================================
 
@@ -40,17 +40,16 @@ using namespace std ;
 
 ClassImp(AliGenDimuon)
 
-//====================================================================================================================================================
+  //====================================================================================================================================================
 
-AliGenDimuon::AliGenDimuon():
-  AliGenerator(), 
-  fPt(0x0),
-  fRap(0x0),
-  fPdgCode(0),
-  fBW(0x0){
+  AliGenDimuon::AliGenDimuon() : AliGenerator(),
+                                 fPt(0x0),
+                                 fRap(0x0),
+                                 fPdgCode(0),
+                                 fBW(0x0)
+{
 
   // Default constructor
-    
 }
 
 //====================================================================================================================================================
@@ -65,7 +64,7 @@ AliGenDimuon::AliGenDimuon(Int_t nPart/*, Char_t *inputFile*/):
 
   fName  = "ParamDimuons";
   fTitle = "Parametric muon pair generator";
-  
+
   SetPtShape();
   SetRapidityShape();
 
@@ -77,7 +76,7 @@ AliGenDimuon::AliGenDimuon(Int_t nPart/*, Char_t *inputFile*/):
 void AliGenDimuon::Generate() {
 
   // Generate one trigger
-  
+
   Double_t polar[3]= {0,0,0};
   Int_t nt;
   Double_t origin[3];
@@ -90,7 +89,7 @@ void AliGenDimuon::Generate() {
   Double_t phi=0.;
   Double_t time=0.;
   Double_t theta = 0.;
-    
+
   Int_t pdgCode1;
   Int_t pdgCode2;
 
@@ -102,7 +101,7 @@ void AliGenDimuon::Generate() {
   Double_t mom1    = 0;
   Double_t rap1    = 0;
   Double_t theta1  = 0;
-  
+
   Double_t energy2 = 0;
   Double_t px2     = 0;
   Double_t py2     = 0;
@@ -111,7 +110,7 @@ void AliGenDimuon::Generate() {
   Double_t mom2    = 0;
   Double_t rap2    = 0;
   Double_t theta2  = 0;
- 
+
   for (Int_t j=0; j<3; j++) origin[j] = fOrigin[j];
   time = fTimeOrigin;
   if (fVertexSmear==kPerEvent) {
@@ -121,7 +120,7 @@ void AliGenDimuon::Generate() {
   }
 
   Int_t nPartGenerated = 2;
-    
+
   Double_t m_muon       = TDatabasePDG::Instance()->GetParticle(13)->Mass();
   Double_t mass_parent  = TDatabasePDG::Instance()->GetParticle(fPdgCode)->Mass();
   Double_t width_parent = TDatabasePDG::Instance()->GetParticle(fPdgCode)->Width();
@@ -134,48 +133,48 @@ void AliGenDimuon::Generate() {
 
     //mass = fBW->GetRandom();
     mass = mass_parent;
-    
+
     if(mass<2*m_muon){
       continue;
     }
     else{
       break;
-    }        
+    }
   }
   */
-  
+
   Double_t daughter_m[2]={m_muon,m_muon};
-  
+
   TLorentzVector rest_p(0,0,0,mass);
 
   TGenPhaseSpace ps_decay;
   ps_decay.SetDecay(rest_p,2,daughter_m);
-  
+
   while (1){;
-    
+
     ps_decay.Generate();
-    
+
     pt  = fPt  -> GetRandom(0.,10);
     rap = fRap -> GetRandom(-3.6,-2.5);
     phi = gRandom->Uniform(0.,TMath::TwoPi());
-    
+
     if (TestBit(kPtRange)       && (pt<fPtMin || pt>fPtMax))             continue;
     if (TestBit(kYRange)        && (rap<fYMin || rap>fYMax))             continue;
-  
+
     TLorentzVector parent;
     parent.SetPtEtaPhiM(pt,rap,phi,mass);
-    
+
     mom   = parent.P();
     theta = parent.Theta();
-    
+
     TVector3 vec_boost =parent.BoostVector();
-    
+
     TLorentzVector* muon1 = ps_decay.GetDecay(0);
     TLorentzVector* muon2 = ps_decay.GetDecay(1);
 
     muon1->Boost(vec_boost);
     muon2->Boost(vec_boost);
-        
+
     energy1 = muon1->E();
     px1     = muon1->Px();
     py1     = muon1->Py();
@@ -187,11 +186,11 @@ void AliGenDimuon::Generate() {
 
     //if (TestBit(kPtRange)       && (pt1<fPtMin || pt1>fPtMax))             continue;
     if (TestBit(kYRange)        && (rap1<fYMin || rap1>fYMax))             continue;
-    //if (TestBit(kMomentumRange) && (mom1<fPMin || mom1>fPMax))             continue;    
+    //if (TestBit(kMomentumRange) && (mom1<fPMin || mom1>fPMax))             continue;
     //if (TestBit(kThetaRange)    && (theta1<fThetaMin || theta1>fThetaMax)) continue;
 
     if(mom1<4.0) continue;
-    
+
     energy2 = muon2->E();
     px2     = muon2->Px();
     py2     = muon2->Py();
@@ -203,11 +202,11 @@ void AliGenDimuon::Generate() {
 
     //if (TestBit(kPtRange)       && (pt2<fPtMin || pt2>fPtMax))             continue;
     if (TestBit(kYRange)        && (rap2<fYMin || rap2>fYMax))             continue;
-    //if (TestBit(kMomentumRange) && (mom2<fPMin || mom2>fPMax))             continue;    
+    //if (TestBit(kMomentumRange) && (mom2<fPMin || mom2>fPMax))             continue;
     //if (TestBit(kThetaRange)    && (theta2<fThetaMin || theta2>fThetaMax)) continue;
 
     if(mom2<4.0) continue;
-    
+
     if (gRandom->Rndm() < 0.5){
       pdgCode1 =  13;
       pdgCode2 = -13;
@@ -222,34 +221,34 @@ void AliGenDimuon::Generate() {
               origin[0],origin[1],origin[2],Double_t(time),
               polar[0],polar[1],polar[2],
               kPPrimary, nt, 1., 1);
-    
+
     PushTrack(1, -1, Int_t(pdgCode2),
-              px2,py2,pz2,energy2,
-              origin[0],origin[1],origin[2],Double_t(time),
-              polar[0],polar[1],polar[2],
-              kPPrimary, nt, 1., 1);    
+              px2, py2, pz2, energy2,
+              origin[0], origin[1], origin[2], Double_t(time),
+              polar[0], polar[1], polar[2],
+              kPPrimary, nt, 1., 1);
 
     //cout<<pt<<"    "<<mom1<<"    "<<mom2<<endl;
-    
+
     TLorentzVector muon12 = *muon1 + *muon2;
     //cout<<muon12.Pt()<<"   "<<muon12.Eta()<<"   "<<muon12.M()<<endl;
-    
+
     /*
     Double_t m1  = muon1->M();
     Double_t px1 = muon1->Px();
     Double_t py1 = muon1->Py();
     Double_t pz1 = muon1->Pz();
-    Double_t p1  = sqrt(px1*px1 + py1*py1 + pz1*pz1);    
+    Double_t p1  = sqrt(px1*px1 + py1*py1 + pz1*pz1);
     Double_t e1  = sqrt(m1*m1 + p1*p1);
 
     Double_t m2  = muon2->M();
     Double_t px2 = muon2->Px();
     Double_t py2 = muon2->Py();
     Double_t pz2 = muon2->Pz();
-    Double_t p2  = sqrt(px2*px2 + py2*py2 + pz2*pz2);    
+    Double_t p2  = sqrt(px2*px2 + py2*py2 + pz2*pz2);
     Double_t e2  = sqrt(m2*m2 + p2*p2);
     */
-    
+
     break;
   }
 
@@ -257,15 +256,13 @@ void AliGenDimuon::Generate() {
   header->SetPrimaryVertex(fVertex);
   header->SetNProduced(nPartGenerated);
   header->SetInteractionTime(fTime);
-  
+
   // Passes header either to the container or to gAlice
   if (fContainer) {
     fContainer->AddHeader(header);
-  } 
-  else {
-    gAlice->SetGenEventHeader(header);	
+  } else {
+    gAlice->SetGenEventHeader(header);
   }
-
 }
 
 //====================================================================================================================================================
@@ -273,44 +270,32 @@ void AliGenDimuon::Generate() {
 void AliGenDimuon::Init() {
 
   // Initialisation, check consistency of selected ranges
-  /*
-  if (TestBit(kPtRange) && TestBit(kMomentumRange)) 
-    Fatal("Init","You should not set the momentum range and the pt range at the same time!\n");
-  if ((!TestBit(kPtRange)) && (!TestBit(kMomentumRange))) 
-    Fatal("Init","You should set either the momentum or the pt range!\n");
-  if ((TestBit(kYRange) && TestBit(kThetaRange)) || (TestBit(kYRange) && TestBit(kEtaRange)) || (TestBit(kEtaRange) && TestBit(kThetaRange)))
-    Fatal("Init","You should only set the range of one of these variables: y, eta or theta\n");
-  if ((!TestBit(kYRange)) && (!TestBit(kEtaRange)) && (!TestBit(kThetaRange)))
-    Fatal("Init","You should set the range of one of these variables: y, eta or theta\n");
-  */
-  ///*
-  if (TestBit(kPtRange) && TestBit(kMomentumRange)) 
+
+  if (TestBit(kPtRange) && TestBit(kMomentumRange))
     printf("You should not set the momentum range and the pt range at the same time!\n");
-  if ((!TestBit(kPtRange)) && (!TestBit(kMomentumRange))) 
+  if ((!TestBit(kPtRange)) && (!TestBit(kMomentumRange)))
     printf("You should set either the momentum or the pt range!\n");
   if ((TestBit(kYRange) && TestBit(kThetaRange)) || (TestBit(kYRange) && TestBit(kEtaRange)) || (TestBit(kEtaRange) && TestBit(kThetaRange)))
     printf("You should only set the range of one of these variables: y, eta or theta\n");
   if ((!TestBit(kYRange)) && (!TestBit(kEtaRange)) && (!TestBit(kThetaRange)))
     printf("You should set the range of one of these variables: y, eta or theta\n");
-  //*/
+
   AliPDG::AddParticlesToPdgDataBase();
-  
 }
 
 //====================================================================================================================================================
 
 void AliGenDimuon::SetPtShape(){
-  
+
   Double_t Ae = 187.;
   Double_t Te = 0.39;
   Double_t m0 = 0.135;
   Double_t A  = 1526.;
   Double_t T  = 0.29;
   Double_t n  = 2.75;
-  
+
   fPt = new TF1("fPt","[0]*exp(-(sqrt(x*x + [1]*[1])-[1])/[2]) + [3]*pow(1+x*x/([4]*[4]*[5]),-[5])",0,10);
   fPt->SetParameters(Ae,Te,m0,A,T,n);
-  
 }
 
 //====================================================================================================================================================
@@ -321,8 +306,7 @@ void AliGenDimuon::SetRapidityShape(){
   Double_t p2 = -0.0988071;
   Double_t p3 = -0.000452746;
   Double_t p4 = 0.00269782;
-  
+
   fRap = new TF1("fRap","[0]*(1 + [1]*x + [2]*x*x + [3]*x*x*x + [4]*x*x*x*x)",-10,10);
   fRap->SetParameters(p0,p1,p2,p3,p4);
-  
 }

--- a/generators/Config.C
+++ b/generators/Config.C
@@ -268,84 +268,49 @@ void Config() {
     gener->AddGenerator(gPions, "PIONS", 1);
   }
 
-  if (MCHgen.find("JPsiParam") < MCHgen.length()) {
-    std::cout << " This is JPsiParam generator! " << std::endl;
-
-    Int_t nJPsi;
-    if (gSystem->Getenv("NJPSI")) {
-      nJPsi = atoi(gSystem->Getenv("NJPSI"));
-      std::cout << " Defined nJPsi =  " << nJPsi << std::endl;
-
-    } else {
-      std::cout << " Default nJPsi = 1 " << std::endl;
-      nJPsi = 1;
-    }
-
-    genMatcherLog << "_" << nJPsi << "jpsi";
-
-    AliGenParam *gJPsi = new AliGenParam(nJPsi, AliGenMUONlib::kJpsi);
-    gJPsi->SetMomentumRange(0, 999);
-    gJPsi->SetPtRange(0, 100.);
-    gJPsi->SetPhiRange(0., 360.);
-    gJPsi->SetCutOnChild(1);
-    gJPsi->SetChildPhiRange(0., 360.);
-    gJPsi->SetChildThetaRange(171.0, 178.0);
-    gJPsi->SetOrigin(0, 0, 0);
-    gJPsi->SetForceDecay(kDiMuon);
-    gJPsi->SetTrackingFlag(1);
-    gener->AddGenerator(gJPsi, "JPSI", 1);
-  }
-
   if (MCHgen.find("hijing") < MCHgen.length()) { // Hijing generator
-    std::cout << " This is hijing generator! " << std::endl;
-    /*
-    AliGenHijing *gener = new AliGenHijing(-1);
-    // centre of mass energy
-    gener->SetEnergyCMS(5500.);
-    // reference frame
-    gener->SetReferenceFrame("CMS");
-    // projectile
-    gener->SetProjectile("A", 208, 82);
-    gener->SetTarget("A", 208, 82);
-    // tell hijing to keep the full parent child chain
-    gener->KeepFullEvent();
-    // enable jet quenching
-    gener->SetJetQuenching(1);
-    // enable shadowing
-    gener->SetShadowing(1);
-    // neutral pion and heavy particle decays switched off
-    gener->SetDecaysOff(1);
-    // Don't track spectators
-    gener->SetSpectators(0);
-    // kinematic selection
-    gener->SetSelectAll(0);
-    // impact parameter range
-    gener->SetImpactParameterRange(0., 5.); // 0. - 5. fm corresponds to ~10% most central
-    gener->Init();
-    */
-
-    AliGenMimicPbPb *mimic_pbpb = new AliGenMimicPbPb(1);
+    std::cout << " This is mimic hijing 0-10 generator! " << std::endl;
+    AliGenMimicPbPb* mimic_pbpb = new AliGenMimicPbPb(1);
     mimic_pbpb->Init();
     gener->AddGenerator(mimic_pbpb, "MIMIC_PBPB", 1);
-    
-    
   }
-  if (MCHgen.find("muoncocktail") < MCHgen.length()) { // Muon cocktail for PbPb
-    std::cout << " This is muoncocktail generator! " << std::endl;
-    AliGenMUONCocktail *generMUONCocktail = new AliGenMUONCocktail();
-    generMUONCocktail->SetPtRange(1., 100.);  // Transverse momentum range
-    generMUONCocktail->SetPhiRange(0., 360.); // Azimuthal angle range
-    generMUONCocktail->SetYRange(-4.0, -2.5);
-    generMUONCocktail->SetMuonPtCut(0.5);
-    generMUONCocktail->SetMuonThetaCut(171., 178.);
-    generMUONCocktail->SetMuonMultiplicity(2);
-    generMUONCocktail->SetImpactParameterRange(
-        0., 5.); // 10% most centra PbPb collisions
-    generMUONCocktail->SetVertexSmear(kPerTrack);
-    generMUONCocktail->SetOrigin(0, 0, 0); // Vertex position
-    generMUONCocktail->SetSigma(0, 0,
-                                0.0); // Sigma in (X,Y,Z) (cm) on IP position
-    gener->AddGenerator(generMUONCocktail, "MUONCocktail", 1);
+
+  if (MCHgen.find("dimuon") < MCHgen.length()) { // Dimuon generator
+    std::cout << " This is dimuon generator! " << std::endl;
+
+    Int_t nJPsi = 0;
+    if (gSystem->Getenv("NJPSI")) {
+      nJPsi = atoi(gSystem->Getenv("NJPSI"));
+      std::cout << " nJPsi =  " << nJPsi << std::endl;
+      genMatcherLog << "_" << nJPsi << "JPsi";
+    }
+
+    Int_t nUpsilon = 0;
+    if (gSystem->Getenv("NUPSILON")) {
+      nUpsilon = atoi(gSystem->Getenv("NUPSILON"));
+      std::cout << " nUpsilon =  " << nUpsilon << std::endl;
+      genMatcherLog << "_" << nUpsilon << "Upsilon";
+    }
+
+    for (int i_jpsi = 0; i_jpsi < nJPsi; i_jpsi++) {
+      AliGenDimuon* dimuonJPsiGen = new AliGenDimuon(1);
+      dimuonJPsiGen->SetGenerateParticle(443);
+      dimuonJPsiGen->SetPtRange(1., 100.);  // Transverse momentum range
+      dimuonJPsiGen->SetPhiRange(0., 360.); // Azimuthal angle range
+      dimuonJPsiGen->SetThetaRange(thmin, thmax);
+      dimuonJPsiGen->Init();
+      gener->AddGenerator(dimuonJPsiGen, Form("JPSI_%d", i_jpsi), 1);
+    }
+
+    for (int i_upsilon = 0; i_upsilon < nUpsilon; i_upsilon++) {
+      AliGenDimuon* dimuonUpsilonGen = new AliGenDimuon(1);
+      dimuonUpsilonGen->SetGenerateParticle(553);
+      dimuonUpsilonGen->SetPtRange(1., 100.);  // Transverse momentum range
+      dimuonUpsilonGen->SetPhiRange(0., 360.); // Azimuthal angle range
+      dimuonUpsilonGen->SetThetaRange(thmin, thmax);
+      dimuonUpsilonGen->Init();
+      gener->AddGenerator(dimuonUpsilonGen, Form("UPSILON_%d", i_upsilon), 1);
+    }
   }
 
   Int_t nEvts;

--- a/generators/sim.C
+++ b/generators/sim.C
@@ -10,7 +10,8 @@ void sim(Int_t nev = 4) {
   gROOT->ProcessLine(".include $ALICE_ROOT/include");
   gSystem->AddIncludePath("-I. -I$ROOTSYS/include -I$ALICE_ROOT/include -I$ALICE_PHYSICS/include -I$ALIDPG_ROOT/include");
   gROOT->LoadMacro("./AliGenMimicPbPb.cxx++g");
-  
+  gROOT->LoadMacro("./AliGenDimuon.cxx++g");
+
   AliSimulation simulator;
   simulator.SetMakeSDigits("MUON");
   // simulator.SetMakeDigitsFromHits("ITS");

--- a/matcher.sh
+++ b/matcher.sh
@@ -17,7 +17,7 @@ Usage()
   ${0##*/} --genMCH -n <number_of_events> -o <outputdir> -g <generator> <generator options>
 
     -g
-     Sets the generator for MCH and MFT tracks. Options:
+     Sets one or more generators for MCH and MFT simulations. Options:
 
       gun0_100GeV - Box generator for pions and muons with total momentum 0 to 100 GeV. (default)
                     Set number of pions and muons on each event:
@@ -28,9 +28,6 @@ Usage()
                        Set number of muons on each event:
            --nmuons <number_of_muons>
 
-      Other tentative generators added to Config.C (not validated):
-
-
       PiMuParam - AliGenParam pions and muons generator with realistic parametrized distributions.
                   Set number of pions and muons on each event:
           --npions <number_of_pions>
@@ -40,17 +37,16 @@ Usage()
                   Set number of pions and muons on each event:
           --npions <number_of_pions>
 
+      hijing  - Mimic Hijing generator for particle background corresponding to the 0-10 most central PbPb collisions
 
-     JPsiParam - add J/Psi's to the cocktail (WARNING: current approach does not handle decays correctly in O2)
-                 Set number of J/Psi's on each event:
-         --njpsis <number_of_njpsis>
+      dimuon  - Generate dimuons decays from J/Psi and/or Upsilon. At least one kind of mother particle must be defined.
+                 To set the number of mother particles on each event:
+         --njpsis <number of J/Psis>
+         --nupsilons <number of Upsilons>
 
-
-      hijing    - ?
-      muoncocktail - ?
-
-    Example:
+    Examples:
     ${0##*/} --genMCH -g gun0_100GeV -n 20 --nmuons 4 --npions 20 -o sampletest
+    ${0##*/} --genMCH -g hijing -g dimuon --njpsis 10 --nupsilons 10 -n 20 -o sampletest
 
   2) Generate MFT Tracks:
      ${0##*/} --genMFT -o <outputdir> -j <jobs>
@@ -393,6 +389,10 @@ while [ $# -gt 0 ] ; do
     ;;
     --njpsis)
     export NJPSI="$2";
+    shift 2
+    ;;
+    --nupsilons)
+    export NUPSILON="$2";
     shift 2
     ;;
     -g)


### PR DESCRIPTION
This PR enables dimuon generators for J/Psi and Upsilon. Pt and eta distributions may need tuning. 

Examples
* dimuons from 10 J/Psis and 10 Upsions:
  * `matcher.sh --genMCH -g dimuon --njpsis 10 --nupsilons 10 -n 20 -o 
sampletest`
* dimuons from 10 J/Psis and 10 Upsions embedded in a mimic Hijing 
background:
  * `matcher.sh --genMCH -g hijing -g dimuon --njpsis 10 --nupsilons 10 
-n 20 -o sampletest`