### PR TITLE
Add Hiroshima score method

### DIFF
--- a/MUONMatcher.cxx
+++ b/MUONMatcher.cxx
@@ -1669,8 +1669,8 @@ double MUONMatcher::matchMFT_MCH_TracksAllParam(const MCHTrackConv& mchTrack,
 }
 
 //_________________________________________________________________________________________________
-double MUONMatcher::Hiroshima(const GlobalMuonTrack& mchTrack,
-                              const MFTTrack& mftTrack)
+double MUONMatcher::matchHiroshima(const GlobalMuonTrack& mchTrack,
+                                   const MFTTrack& mftTrack)
 {
 
   //Hiroshima's Matching function

--- a/MUONMatcher.cxx
+++ b/MUONMatcher.cxx
@@ -1669,20 +1669,20 @@ double MUONMatcher::matchMFT_MCH_TracksAllParam(const MCHTrackConv& mchTrack,
 }
 
 //_________________________________________________________________________________________________
-double MUONMatcher::Hiroshima(const GlobalMuonTrack &mchTrack,
-			      const MFTTrack &mftTrack) {
+double MUONMatcher::Hiroshima(const GlobalMuonTrack& mchTrack,
+                              const MFTTrack& mftTrack)
+{
 
   //Hiroshima's Matching function
 
   //Matching constants
-  Double_t LAbs = 415.;  //Absorber Length[cm]
+  Double_t LAbs = 415.;    //Absorber Length[cm]
   Double_t mumass = 0.106; //mass of muon [GeV/c^2]
-  Double_t l;  //the length that extrapolated MCHtrack passes through absorber
+  Double_t l;              //the length that extrapolated MCHtrack passes through absorber
 
-  if (mMatchingPlaneZ >= -90.0){
+  if (mMatchingPlaneZ >= -90.0) {
     l = LAbs;
-  }
-  else{
+  } else {
     l = 505.0 + mMatchingPlaneZ;
   }
 
@@ -1696,39 +1696,39 @@ double MUONMatcher::Hiroshima(const GlobalMuonTrack &mchTrack,
   //Multiple Scattering(=MS)
 
   auto pMCH = mchTrack.getP();
-  auto lorentzbeta = pMCH/TMath::Sqrt(mumass*mumass+pMCH*pMCH);
-  auto zMS = copysign(1.0,mchTrack.getCharge());
-  auto thetaMS = 13.6/(1000.0*pMCH*lorentzbeta*1.0)*zMS*TMath::Sqrt(60.0*l/LAbs)*(1.0+0.038*TMath::Log(60.0*l/LAbs));
-  auto xMS = thetaMS*l/TMath::Sqrt(3.0);
+  auto lorentzbeta = pMCH / TMath::Sqrt(mumass * mumass + pMCH * pMCH);
+  auto zMS = copysign(1.0, mchTrack.getCharge());
+  auto thetaMS = 13.6 / (1000.0 * pMCH * lorentzbeta * 1.0) * zMS * TMath::Sqrt(60.0 * l / LAbs) * (1.0 + 0.038 * TMath::Log(60.0 * l / LAbs));
+  auto xMS = thetaMS * l / TMath::Sqrt(3.0);
 
   //normalize by theoritical Multiple Coulomb Scattering width to be momentum-independent
   //make the dx and dtheta dimensionless
 
-  auto dxnorm = dx/xMS;
-  auto dynorm = dy/xMS;
-  auto dthetaxnorm = dthetax/thetaMS;
-  auto dthetaynorm = dthetay/thetaMS;
+  auto dxnorm = dx / xMS;
+  auto dynorm = dy / xMS;
+  auto dthetaxnorm = dthetax / thetaMS;
+  auto dthetaynorm = dthetay / thetaMS;
 
   //rotate distribution
 
-  auto dxrot = dxnorm*TMath::Cos(TMath::Pi()/4.0)-dthetaxnorm*TMath::Sin(TMath::Pi()/4.0);
-  auto dthetaxrot = dxnorm*TMath::Sin(TMath::Pi()/4.0)+dthetaxnorm*TMath::Cos(TMath::Pi()/4.0);
-  auto dyrot = dynorm*TMath::Cos(TMath::Pi()/4.0)-dthetaynorm*TMath::Sin(TMath::Pi()/4.0);
-  auto dthetayrot = dynorm*TMath::Sin(TMath::Pi()/4.0)+dthetaynorm*TMath::Cos(TMath::Pi()/4.0);
+  auto dxrot = dxnorm * TMath::Cos(TMath::Pi() / 4.0) - dthetaxnorm * TMath::Sin(TMath::Pi() / 4.0);
+  auto dthetaxrot = dxnorm * TMath::Sin(TMath::Pi() / 4.0) + dthetaxnorm * TMath::Cos(TMath::Pi() / 4.0);
+  auto dyrot = dynorm * TMath::Cos(TMath::Pi() / 4.0) - dthetaynorm * TMath::Sin(TMath::Pi() / 4.0);
+  auto dthetayrot = dynorm * TMath::Sin(TMath::Pi() / 4.0) + dthetaynorm * TMath::Cos(TMath::Pi() / 4.0);
 
   //convert ellipse to circle
 
-  auto k = 0.7;  //need to optimize!!
+  auto k = 0.7; //need to optimize!!
   auto dxcircle = dxrot;
   auto dycircle = dyrot;
-  auto dthetaxcircle = dthetaxrot/k;
-  auto dthetaycircle = dthetayrot/k;
+  auto dthetaxcircle = dthetaxrot / k;
+  auto dthetaycircle = dthetayrot / k;
 
   //score
 
-  auto scoreX = TMath::Sqrt( dxcircle*dxcircle + dthetaxcircle*dthetaxcircle );
-  auto scoreY = TMath::Sqrt( dycircle*dycircle + dthetaycircle*dthetaycircle );
-  auto score = TMath::Sqrt( scoreX*scoreX + scoreY*scoreY );
+  auto scoreX = TMath::Sqrt(dxcircle * dxcircle + dthetaxcircle * dthetaxcircle);
+  auto scoreY = TMath::Sqrt(dycircle * dycircle + dthetaycircle * dthetaycircle);
+  auto score = TMath::Sqrt(scoreX * scoreX + scoreY * scoreY);
 
   return score;
 };

--- a/MUONMatcher.h
+++ b/MUONMatcher.h
@@ -141,8 +141,8 @@ class MUONMatcher
   double matchMFT_MCH_TracksAllParam(const MCHTrackConv& mchTrack,
                                      const MFTTrack& mftTrack);
   //// Hiroshima's Matching
-  double Hiroshima(const GlobalMuonTrack& mchTrack,
-                   const MFTTrack& mftTrack);
+  double matchHiroshima(const GlobalMuonTrack& mchTrack,
+                        const MFTTrack& mftTrack);
   //// Matching using trained ML
   double matchTrainedML(const MCHTrackConv& mchTrack,
                         const MFTTrack& mftTrack);
@@ -159,6 +159,9 @@ class MUONMatcher
     }
     if (func == &MUONMatcher::matchMFT_MCH_TracksAllParam) {
       mMatchingHelper.MatchingFunction = "_matchAllParams";
+    }
+    if (func == &MUONMatcher::matchHiroshima) {
+      mMatchingHelper.MatchingFunction = "_matchHiroshima";
     }
     if (func == &MUONMatcher::matchTrainedML) {
       mMatchingHelper.MatchingFunction = "_matchML";

--- a/MUONMatcher.h
+++ b/MUONMatcher.h
@@ -141,8 +141,8 @@ class MUONMatcher
   double matchMFT_MCH_TracksAllParam(const MCHTrackConv& mchTrack,
                                      const MFTTrack& mftTrack);
   //// Hiroshima's Matching
-  double Hiroshima(const GlobalMuonTrack &mchTrack,
-		   const MFTTrack &mftTrack);
+  double Hiroshima(const GlobalMuonTrack& mchTrack,
+                   const MFTTrack& mftTrack);
   //// Matching using trained ML
   double matchTrainedML(const MCHTrackConv& mchTrack,
                         const MFTTrack& mftTrack);

--- a/MUONMatcher.h
+++ b/MUONMatcher.h
@@ -140,7 +140,9 @@ class MUONMatcher
   //// Position, Angles & Charged Momentum
   double matchMFT_MCH_TracksAllParam(const MCHTrackConv& mchTrack,
                                      const MFTTrack& mftTrack);
-
+  //// Hiroshima's Matching
+  double Hiroshima(const GlobalMuonTrack &mchTrack,
+		   const MFTTrack &mftTrack);
   //// Matching using trained ML
   double matchTrainedML(const MCHTrackConv& mchTrack,
                         const MFTTrack& mftTrack);

--- a/matcher.sh
+++ b/matcher.sh
@@ -74,6 +74,8 @@ Usage()
 
          matchXY - matching chi2 calculated track positions: X, Y
 
+         matchHiroshima - Hiroshima matching function
+
          trainedML - matching using a trained neural network (see TMVA interface bellow)
 
      --cutFcn

--- a/runMatching.C
+++ b/runMatching.C
@@ -64,7 +64,7 @@ void loadAndSetMatchingConfig()
       std::cout << " Setting " << matching_fcn << std::endl;
       matcher.setMatchingFunction(&MUONMatcher::matchMFT_MCH_TracksAllParam);
     }
-    if (matching_fcn.find("Hiroshima_") < matching_fcn.length()){
+    if (matching_fcn.find("Hiroshima_") < matching_fcn.length()) {
       std::cout << " Setting " << matching_fcn << std::endl;
       matcher.setMatchingFunction(&MUONMatcher::Hiroshima);
     }

--- a/runMatching.C
+++ b/runMatching.C
@@ -64,9 +64,9 @@ void loadAndSetMatchingConfig()
       std::cout << " Setting " << matching_fcn << std::endl;
       matcher.setMatchingFunction(&MUONMatcher::matchMFT_MCH_TracksAllParam);
     }
-    if (matching_fcn.find("Hiroshima_") < matching_fcn.length()) {
+    if (matching_fcn.find("matchHiroshima_") < matching_fcn.length()) {
       std::cout << " Setting " << matching_fcn << std::endl;
-      matcher.setMatchingFunction(&MUONMatcher::Hiroshima);
+      matcher.setMatchingFunction(&MUONMatcher::matchHiroshima);
     }
     if (matching_fcn.find("trainedML_") < matching_fcn.length()) {
       std::cout << " Setting " << matching_fcn << std::endl;

--- a/runMatching.C
+++ b/runMatching.C
@@ -64,6 +64,10 @@ void loadAndSetMatchingConfig()
       std::cout << " Setting " << matching_fcn << std::endl;
       matcher.setMatchingFunction(&MUONMatcher::matchMFT_MCH_TracksAllParam);
     }
+    if (matching_fcn.find("Hiroshima_") < matching_fcn.length()){
+      std::cout << " Setting " << matching_fcn << std::endl;
+      matcher.setMatchingFunction(&MUONMatcher::Hiroshima);
+    }
     if (matching_fcn.find("trainedML_") < matching_fcn.length()) {
       std::cout << " Setting " << matching_fcn << std::endl;
       matcher.setMatchingFunction(&MUONMatcher::matchTrainedML);


### PR DESCRIPTION
Hiroshima score method is added into MUONMatcher.cxx/.h, runMatching.C.
If you want to use the method, you execute matching command with --matchFcn Hiroshima.